### PR TITLE
set thumbnail size to height/width of container.

### DIFF
--- a/app/assets/stylesheets/ample_assets/files.css.scss
+++ b/app/assets/stylesheets/ample_assets/files.css.scss
@@ -661,6 +661,8 @@ textarea {
       }
       img {
         border: none;
+        width: 100%;
+        height: 100%;
       }
     } //file a
      


### PR DESCRIPTION
Fixes thumbnail overflow issue. 
![Screen Shot 2013-04-12 at 4 24 25 PM](https://f.cloud.github.com/assets/354485/374988/1541681e-a3af-11e2-957f-b072c495ed16.png)
