### PR TITLE
Quick and dirty set redirect_to URL after asset upload.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ample_assets (0.0.9)
+    ample_assets (0.0.10)
       acts_as_indexed
       coffee-rails (~> 3.2.1)
       coffee_cup

--- a/app/controllers/ample_assets/files_controller.rb
+++ b/app/controllers/ample_assets/files_controller.rb
@@ -26,7 +26,7 @@ module AmpleAssets
         if uploadify?
           render :nothing => true
         else
-          redirect_to :back
+          redirect_to params[:return_to]
         end
       else
         flash[:error] = "Whoops! There was a problem creating new asset."

--- a/app/views/ample_assets/files/new.html.erb
+++ b/app/views/ample_assets/files/new.html.erb
@@ -1,5 +1,8 @@
-<%= form_for AmpleAssets::File.new, :multipart => true, :remote => true do |f| %>
+<%= form_for AmpleAssets::File.new, :multipart => true do |f| %>
   <%= f.label :attachment %>
   <%= f.file_field :attachment %>
   <%= f.submit %>
 <% end %>
+<script>
+ $('#new_file').append('<input type="hidden" name="return_to" value="'+document.location.href+'">')
+</script>

--- a/lib/ample_assets/version.rb
+++ b/lib/ample_assets/version.rb
@@ -1,3 +1,3 @@
 module AmpleAssets
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end


### PR DESCRIPTION
Less than elegant way to pass the `return_to` URL to the files controller. Previously used `redirect_to :back` but the referrer is not always the "parent" page/post URL